### PR TITLE
Przykład obsługi zdarzeń w Scene2d

### DIFF
--- a/core/src/com/samsung/project/Scenes/ControlPanel.java
+++ b/core/src/com/samsung/project/Scenes/ControlPanel.java
@@ -6,8 +6,8 @@ import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.scenes.scene2d.Event;
-import com.badlogic.gdx.scenes.scene2d.EventListener;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.utils.viewport.FitViewport;
@@ -50,6 +50,13 @@ public class ControlPanel {
         btnUp = createButton(CastleRunner.V_WIDTH * 0.125f, btnUpImg);
         btnLeft = createButton((CastleRunner.V_WIDTH * 0.875f) - 25, btnLeftImg);
         btnRight = createButton((CastleRunner.V_WIDTH * 0.875f) + 25, btnRightImg);
+        btnUp.addListener(new InputListener() {
+            @Override
+            public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+                Gdx.app.log("Touch", "touchDown() UP");
+                return true;
+            }
+        });
 
         stage.addActor(btnUp);
         stage.addActor(btnLeft);

--- a/core/src/com/samsung/project/Screens/GameScreen.java
+++ b/core/src/com/samsung/project/Screens/GameScreen.java
@@ -36,6 +36,12 @@ public class GameScreen extends AbstractScreen {
     }
 
     @Override
+    public void show() {
+        super.show();
+        Gdx.input.setInputProcessor(controlPanel.stage);
+    }
+
+    @Override
     public void render(float delta) {
         Gdx.gl.glClearColor(0f, 0f, 0f, 1f);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);


### PR DESCRIPTION
Przykład przedstawia, w jaki sposób przechwycić zdarzenie naciśnięcia przycisku UP. Do poprawnego działania dana scena musi być wcześniej ustawiona jako InputProcessor.

Sceny z LibGDX przypominają strukturą widoki z Androida. Zatem mają swoja hierarchię, system rozmieszczania obiektów na scenie (layouts), animacje oraz rozsyłanie zdarzeń do poszczególnych aktorów.

Klasa Stage odpowiada za rozsyłanie zdarzeń do podpiętych aktorów, więc powinna zadbać o odpowiednie przetworzenie współrzędnych ekranu na współrzędne lokalne w jakich wyświetlane są przyciski.

Daj znać czy to pomogło. :)

Więcej: https://github.com/libgdx/libgdx/wiki/Scene2d